### PR TITLE
remove hard code of "mysql"

### DIFF
--- a/sqli-repo/src/main/java/io/xream/sqli/starter/InitializerListener.java
+++ b/sqli-repo/src/main/java/io/xream/sqli/starter/InitializerListener.java
@@ -69,7 +69,7 @@ public class InitializerListener {
                     throw new UninitializedException("Failed to start sqli-repo, check Bean: " + clz);
                 }
 
-                if (dialect.getKey().contains("mysql") && SqliStringUtil.isNotNull(createSql)) {
+                if (SqliStringUtil.isNotNull(createSql)) {
                     nativeSupport.execute(clz, createSql);
                 }
 


### PR DESCRIPTION
Dialect has add buildTableSql(),  it should remove the hard code of "mysql"